### PR TITLE
Fix order error caused by store library

### DIFF
--- a/log-store.cabal
+++ b/log-store.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 07799ae13781cbf4f7a627c749bc4b42979c55b7e21fb9ea075dd234129a984c
+-- hash: e1aab789e50c7006cd080fd3c7e16dccd476b2ef1a32cbe8465d4c4455d642c3
 
 name:           log-store
 version:        0.1.0.0
@@ -38,15 +38,17 @@ library
   ghc-options: -W
   build-depends:
       base >=4.7 && <5
+    , binary-strict
     , bytestring
+    , bytestring-strict-builder
     , data-default
     , directory
     , filepath
     , mtl
     , resourcet
     , rocksdb-haskell-bindings
-    , store
     , streamly
+    , text
     , transformers
     , utf8-string
     , vector
@@ -63,7 +65,9 @@ test-suite log-store-test
   build-depends:
       QuickCheck
     , base >=4.7 && <5
+    , binary-strict
     , bytestring
+    , bytestring-strict-builder
     , data-default
     , directory
     , filepath
@@ -73,9 +77,9 @@ test-suite log-store-test
     , mtl
     , resourcet
     , rocksdb-haskell-bindings
-    , store
     , streamly
     , temporary-resourcet
+    , text
     , transformers
     , utf8-string
     , vector
@@ -91,7 +95,9 @@ benchmark log-store-benchmark
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -fprof-auto
   build-depends:
       base >=4.7 && <5
+    , binary-strict
     , bytestring
+    , bytestring-strict-builder
     , criterion
     , data-default
     , directory
@@ -100,9 +106,9 @@ benchmark log-store-benchmark
     , mtl
     , resourcet
     , rocksdb-haskell-bindings
-    , store
     , streamly
     , temporary-resourcet
+    , text
     , transformers
     , utf8-string
     , vector

--- a/package.yaml
+++ b/package.yaml
@@ -23,7 +23,8 @@ dependencies:
 - base >= 4.7 && < 5
 - bytestring
 - data-default
-- store
+- bytestring-strict-builder
+- binary-strict
 - resourcet
 - filepath
 - directory
@@ -33,6 +34,7 @@ dependencies:
 - streamly
 - vector
 - utf8-string
+- text
 
 library:
   source-dirs: src

--- a/src/Log/Store/Exception.hs
+++ b/src/Log/Store/Exception.hs
@@ -8,6 +8,7 @@ data LogStoreException
   | LogStoreLogNotFoundException String
   | LogStoreLogAlreadyExistsException String
   | LogStoreUnsupportedOperationException String
+  | LogStoreDecodeException String
   | LogStoreUnknownException String
   deriving (Show, Typeable)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -68,7 +68,5 @@ packages:
 extra-deps:
 - github: hstream-io/haskell-rocksdb-bindings
   commit: 690de8d425f55a28dca07c5b58f9d7bc6571d018
-- store-0.7.4
-- store-core-0.4.4.2
-- th-utilities-0.2.4.0
+- binary-strict-0.4.8.6
 


### PR DESCRIPTION
* store use host byte order, which is little endian and
makes kv out of order using bytewise comparator in rocksdb.

* now use bytestring-strict-builder adnd binary-strict for
encode and decode.